### PR TITLE
fix: SocketException in ModbusClient.disconnect

### DIFF
--- a/src/main/java/de/spyderscript/modbus/tcp/ModbusClient.java
+++ b/src/main/java/de/spyderscript/modbus/tcp/ModbusClient.java
@@ -54,9 +54,6 @@ public class ModbusClient {
 
     public void disconnect() throws IOException {
         if (socket != null) {
-            socket.getInputStream().close();
-            socket.getOutputStream().close();
-
             socket.close();
         }
     }


### PR DESCRIPTION
Fixes a SocketException caused by calling the close() method on the input and output stream manually.
Calling the Sockets default close() method cleanly closes both streams and should therefore be used alone.